### PR TITLE
110 Move Black Pieces to Bottom

### DIFF
--- a/Assets/Assets/Scenes/GameBoard.unity
+++ b/Assets/Assets/Scenes/GameBoard.unity
@@ -1002,7 +1002,6 @@ GameObject:
   m_Component:
   - component: {fileID: 959209905}
   - component: {fileID: 959209904}
-  - component: {fileID: 959209903}
   - component: {fileID: 959209902}
   m_Layer: 0
   m_Name: SkyboxCamera
@@ -1020,14 +1019,6 @@ Skybox:
   m_GameObject: {fileID: 959209901}
   m_Enabled: 1
   m_CustomSkybox: {fileID: 2100000, guid: 617d9be015db68348a623b01ea51a8c5, type: 2}
---- !u!81 &959209903
-AudioListener:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 959209901}
-  m_Enabled: 1
 --- !u!20 &959209904
 Camera:
   m_ObjectHideFlags: 0

--- a/Assets/Assets/Scenes/GameBoard.unity
+++ b/Assets/Assets/Scenes/GameBoard.unity
@@ -913,6 +913,99 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 896491003}
   m_CullTransparentMesh: 1
+--- !u!1 &959209901
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 959209905}
+  - component: {fileID: 959209904}
+  - component: {fileID: 959209903}
+  - component: {fileID: 959209902}
+  m_Layer: 0
+  m_Name: SkyboxCamera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!45 &959209902
+Skybox:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 959209901}
+  m_Enabled: 1
+  m_CustomSkybox: {fileID: 2100000, guid: 617d9be015db68348a623b01ea51a8c5, type: 2}
+--- !u!81 &959209903
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 959209901}
+  m_Enabled: 1
+--- !u!20 &959209904
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 959209901}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 0
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &959209905
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 959209901}
+  m_LocalRotation: {x: 0, y: -1, z: 0, w: 0}
+  m_LocalPosition: {x: 3.5, y: 3.5, z: 10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: -180, z: 0}
 --- !u!1 &991967300
 GameObject:
   m_ObjectHideFlags: 0
@@ -2137,7 +2230,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1368847223
 MonoBehaviour:
@@ -2408,7 +2501,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1634162509
 GameObject:
@@ -2596,7 +2689,7 @@ RectTransform:
   - {fileID: 545627242}
   - {fileID: 1444354410}
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -2734,7 +2827,6 @@ GameObject:
   - component: {fileID: 1706266493}
   - component: {fileID: 1706266492}
   - component: {fileID: 1706266491}
-  - component: {fileID: 1706266494}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -2759,7 +2851,7 @@ Camera:
   m_GameObject: {fileID: 1706266490}
   m_Enabled: 1
   serializedVersion: 2
-  m_ClearFlags: 1
+  m_ClearFlags: 3
   m_BackGroundColor: {r: 0, g: 0, b: 0, a: 0}
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
@@ -2800,22 +2892,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1706266490}
-  m_LocalRotation: {x: 0, y: -1, z: 0, w: 0}
+  m_LocalRotation: {x: -1, y: -0, z: 0, w: 0}
   m_LocalPosition: {x: 3.5, y: 3.5, z: 10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: -180, z: 0}
---- !u!45 &1706266494
-Skybox:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1706266490}
-  m_Enabled: 1
-  m_CustomSkybox: {fileID: 2100000, guid: 617d9be015db68348a623b01ea51a8c5, type: 2}
+  m_LocalEulerAnglesHint: {x: 0, y: -180, z: 180}
 --- !u!1 &1868095168
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Assets/Scenes/GameBoard.unity
+++ b/Assets/Assets/Scenes/GameBoard.unity
@@ -676,6 +676,85 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &597386762
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 597386765}
+  - component: {fileID: 597386764}
+  - component: {fileID: 597386763}
+  m_Layer: 5
+  m_Name: BlackScoreHeading
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &597386763
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 597386762}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.15686275, g: 0.15686275, b: 0.15686275, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 12800000, guid: e3265ab4bf004d28a9537516768c1c75, type: 3}
+    m_FontSize: 36
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 3
+    m_MaxSize: 40
+    m_Alignment: 1
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Black
+--- !u!222 &597386764
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 597386762}
+  m_CullTransparentMesh: 1
+--- !u!224 &597386765
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 597386762}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 96.5, y: 430.56}
+  m_SizeDelta: {x: 119.4338, y: 42.886}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &714218440
 GameObject:
   m_ObjectHideFlags: 0
@@ -710,7 +789,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 96.5, y: -60}
+  m_AnchoredPosition: {x: 96.5, y: 60}
   m_SizeDelta: {x: 65.36, y: 64.2271}
   m_Pivot: {x: 0.5, y: 0.49999994}
 --- !u!114 &714218442
@@ -726,7 +805,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.9803922, g: 0.96470594, b: 0.93725497, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -789,7 +868,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 96.5, y: 113.56}
+  m_AnchoredPosition: {x: 96.5, y: -113.56}
   m_SizeDelta: {x: 119.4338, y: 42.886}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &723299339
@@ -1315,7 +1394,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 96.5, y: 60}
+  m_AnchoredPosition: {x: 96.5, y: -60}
   m_SizeDelta: {x: 65.36, y: 64.2271}
   m_Pivot: {x: 0.5, y: 0.49999994}
 --- !u!114 &1129885351
@@ -1394,7 +1473,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 96.5, y: -113.56}
+  m_AnchoredPosition: {x: 96.5, y: 113.56}
   m_SizeDelta: {x: 124.6297, y: 42.886}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1137151587
@@ -1410,7 +1489,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.9803922, g: 0.96470594, b: 0.93725497, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -1732,7 +1811,7 @@ GameObject:
   - component: {fileID: 1202087040}
   - component: {fileID: 1202087039}
   m_Layer: 5
-  m_Name: PlayerOneNameText
+  m_Name: PlayerTwoNameText
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1750,7 +1829,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1649361409}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -2676,8 +2755,8 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
-  - {fileID: 1202087038}
   - {fileID: 1985158184}
+  - {fileID: 1202087038}
   - {fileID: 299549605}
   - {fileID: 1129885350}
   - {fileID: 714218441}
@@ -2720,8 +2799,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c3db42273f674d04f927bc76c8a46c52, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  playerOne: {fileID: 1202087039}
-  playerTwo: {fileID: 1985158185}
+  playerOne: {fileID: 1985158185}
+  playerTwo: {fileID: 1202087039}
 --- !u!114 &1649361412
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3215,7 +3294,7 @@ GameObject:
   - component: {fileID: 1985158186}
   - component: {fileID: 1985158185}
   m_Layer: 5
-  m_Name: PlayerTwoNameText
+  m_Name: PlayerOneNameText
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -3233,7 +3312,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1649361409}
-  m_RootOrder: 1
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}

--- a/Assets/Assets/Scripts/Piece.cs
+++ b/Assets/Assets/Scripts/Piece.cs
@@ -73,7 +73,6 @@ public class Piece : MonoBehaviour
     {
         if(this.sprite != null)
         {
-            Debug.Log("Rotation: " + Camera.main.transform.localEulerAngles);
             this.sprite.transform.rotation = Quaternion.Euler(0.0f, 0.0f, Camera.main.transform.localEulerAngles.z);
         }
     }

--- a/Assets/Assets/Scripts/Piece.cs
+++ b/Assets/Assets/Scripts/Piece.cs
@@ -52,7 +52,7 @@ public class Piece : MonoBehaviour
         this.sprite.transform.parent = this.transform;
         this.sprite.name = "sprite";
         this.sprite.GetComponent<SpriteRenderer>().sortingOrder = 1;
-
+        this.AlignRotationToCamera();
         return;
     }
 
@@ -67,6 +67,19 @@ public class Piece : MonoBehaviour
 
     /// <summary>
     /// Method
+    /// Rotates the piece so that kings will not appear upside down.
+    /// </summary>
+    public void AlignRotationToCamera()
+    {
+        if(this.sprite != null)
+        {
+            Debug.Log("Rotation: " + Camera.main.transform.localEulerAngles);
+            this.sprite.transform.rotation = Quaternion.Euler(0.0f, 0.0f, Camera.main.transform.localEulerAngles.z);
+        }
+    }
+
+    /// <summary>
+    /// Method
     /// Initializes a piece at a location.
     /// </summary>
     public void InitializePiece(CheckersState.State type, Vector2 position, GameObject whitePiecePrefab, GameObject blackPiecePrefab, GameObject whiteKingPrefab, GameObject blackKingPrefab)
@@ -75,7 +88,11 @@ public class Piece : MonoBehaviour
         this.InitPieceMap();
         this.ResetSprite();
         this.SetPieceType(type);
-        if(this.sprite != null) this.sprite.transform.position = position;
+        if(this.sprite != null)
+        {
+            this.sprite.transform.position = position;
+            this.AlignRotationToCamera();
+        }
         return;
     }
 


### PR DESCRIPTION
### What was Accomplished / Fix Implementation
* The black pieces are now at the bottom of the board. This was a bit more of a hassle than expected, so test carefully:
  * Added a second camera to the gameboard scene that exclusively shows the skybox.
  * The main camera is now rotated 180 degrees on the z axis.
  * Gameboard UI needed to be updated to have player one's name at the bottom, and player two's name at the top.
  * Gameboard score needed to be updated to have black at the bottom and white at the top.
  * Added a method in the piece class that updates the piece's rotation to make sure it is not upside down.

### Testing
* To run unit tests, ensure you have a build set for the `GameBoard` scene
    * `File > Build Settings > Add Open Scenes > Build`
* You also need the Test Runner window open to see the available tests
    * `Window > General > Test Runner`
    * You can dock this where you would like based on your layout preferences
* Click `Run All` in the Test Runner window or select a specific test then click `Run Selected`
* To manually run the scene, press the `play` button or go to `File > Build and Run`
* Other tests:
  * Make sure that black and white captures update the proper score count in the UI.
  * Make sure the player names are in the proper place with respect to which colour they are playing as.
  * Make sure black and white pieces can be selected/moved as expected.
  * Make sure that kings are oriented to always be right-side-up.