### PR TITLE
9.2 game history connection

### DIFF
--- a/Assets/Assets/Prefabs/GameHistoryRow.prefab
+++ b/Assets/Assets/Prefabs/GameHistoryRow.prefab
@@ -300,12 +300,12 @@ MonoBehaviour:
       m_Calls: []
   m_FontData:
     m_Font: {fileID: 12800000, guid: e3265ab4bf004d28a9537516768c1c75, type: 3}
-    m_FontSize: 35
+    m_FontSize: 25
     m_FontStyle: 1
     m_BestFit: 0
-    m_MinSize: 3
+    m_MinSize: 2
     m_MaxSize: 40
-    m_Alignment: 1
+    m_Alignment: 4
     m_AlignByGeometry: 0
     m_RichText: 1
     m_HorizontalOverflow: 0

--- a/Assets/Assets/Scripts/Board.cs
+++ b/Assets/Assets/Scripts/Board.cs
@@ -272,7 +272,7 @@ public class Board : MonoBehaviour
                 RecordKeeper.UpdateRecordLost(NameStaticClass.playerOneName);
                 RecordKeeper.SaveData();
                 GameHistoryRecordKeeper.LoadData();
-                GameHistoryRecordKeeper.AddRecord(NameStaticClass.playerOneName, NameStaticClass.playerTwoName, NameStaticClass.playerTwoName, GetBlackPiecesLost(), GetWhitePiecesLost());
+                GameHistoryRecordKeeper.AddRecord(NameStaticClass.playerOneName, NameStaticClass.playerTwoName, NameStaticClass.playerTwoName, GetWhitePiecesLost(), GetBlackPiecesLost());
                 GameHistoryRecordKeeper.SaveData();
                 updatedRecord = true;
             }
@@ -288,7 +288,7 @@ public class Board : MonoBehaviour
                 RecordKeeper.UpdateRecordLost(NameStaticClass.playerTwoName);
                 RecordKeeper.SaveData();
                 GameHistoryRecordKeeper.LoadData();
-                GameHistoryRecordKeeper.AddRecord(NameStaticClass.playerOneName, NameStaticClass.playerTwoName, NameStaticClass.playerOneName, GetBlackPiecesLost(), GetWhitePiecesLost());
+                GameHistoryRecordKeeper.AddRecord(NameStaticClass.playerOneName, NameStaticClass.playerTwoName, NameStaticClass.playerOneName, GetWhitePiecesLost(), GetBlackPiecesLost());
                 GameHistoryRecordKeeper.SaveData();
                 updatedRecord = true;
             }

--- a/Assets/Assets/Scripts/Board.cs
+++ b/Assets/Assets/Scripts/Board.cs
@@ -271,6 +271,9 @@ public class Board : MonoBehaviour
                 RecordKeeper.UpdateRecordWon(NameStaticClass.playerTwoName);
                 RecordKeeper.UpdateRecordLost(NameStaticClass.playerOneName);
                 RecordKeeper.SaveData();
+                GameHistoryRecordKeeper.LoadData();
+                GameHistoryRecordKeeper.AddRecord(NameStaticClass.playerOneName, NameStaticClass.playerTwoName, NameStaticClass.playerTwoName, GetBlackPiecesLost(), GetWhitePiecesLost());
+                GameHistoryRecordKeeper.SaveData();
                 updatedRecord = true;
             }
             popupChild.SetActive(true);
@@ -284,6 +287,9 @@ public class Board : MonoBehaviour
                 RecordKeeper.UpdateRecordWon(NameStaticClass.playerOneName);
                 RecordKeeper.UpdateRecordLost(NameStaticClass.playerTwoName);
                 RecordKeeper.SaveData();
+                GameHistoryRecordKeeper.LoadData();
+                GameHistoryRecordKeeper.AddRecord(NameStaticClass.playerOneName, NameStaticClass.playerTwoName, NameStaticClass.playerOneName, GetBlackPiecesLost(), GetWhitePiecesLost());
+                GameHistoryRecordKeeper.SaveData();
                 updatedRecord = true;
             }
             popupChild.SetActive(true);

--- a/Assets/Assets/Scripts/GameHistory.cs
+++ b/Assets/Assets/Scripts/GameHistory.cs
@@ -21,7 +21,7 @@ public class GameHistory : MonoBehaviour
             texts[0].text = GameHistoryRecordKeeper.listOfGameHistory[i].blackPlayerName;
             texts[1].text = GameHistoryRecordKeeper.listOfGameHistory[i].whitePlayerName;
             texts[2].text = GameHistoryRecordKeeper.listOfGameHistory[i].blackFinalScore.ToString();
-            texts[3].text = GameHistoryRecordKeeper.listOfGameHistory[i].whitePlayerName.ToString();
+            texts[3].text = GameHistoryRecordKeeper.listOfGameHistory[i].whiteFinalScore.ToString();
             texts[4].text = GameHistoryRecordKeeper.listOfGameHistory[i].gameWinner;
         }
         GameHistoryRecordKeeper.SaveData();


### PR DESCRIPTION
### What was Accomplished

- Connected the game history records to the end game
- When the game ends the player names, winner and points of each player are stored in the list of game records.

### Testing

- Play a game to completion.
- After the game is played, go to the leaderboard section and switch over to the game records.
- You should see the statistics of the latest game played at the top of the list.